### PR TITLE
Moving behat to development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
     ],
     "require": {
         "php": ">=5.4",
-        "guzzlehttp/guzzle": "~4.0",
-        "behat/behat":"~3.0.6"
+        "guzzlehttp/guzzle": "~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.7.*",
+        "behat/behat":"~3.0.6"
     },
     "autoload": {
        "psr-0":{


### PR DESCRIPTION
It was in with the normal `require` directive in composer, but we don't want
library users to have to install that to use the library. So we should put it
in `require-dev` instead.
